### PR TITLE
Switch to ctlib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y tzdata
       - checkout
+      - restore_cache:
+          keys:
+            - opam-v1-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
       - run:
           name: Update opam
           command: |
@@ -39,6 +42,10 @@ jobs:
           # This is a separate step so we don't run tests for dependencies
           name: Install OCaml test dependencies
           command: opam install --deps-only -t -y mssql
+      - save_cache:
+          key: opam-v1-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
+          paths:
+            - ~/.opam
       - run:
           name: Build
           command: opam config exec -- make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,4 +60,6 @@ jobs:
           command: |
             cd _build/default
             shopt -s globstar
-            opam config exec -- ocveralls **/bisect*.out --send --repo_token $COVERALLS_REPO_TOKEN --git
+            if [[ -n "$COVERALLS_REPO_TOKEN" ]]; then
+              opam config exec -- ocveralls **/bisect*.out --send --repo_token $COVERALLS_REPO_TOKEN --git
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - opam-v1-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
+            - opam-v2-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
       - run:
           name: Update opam
           command: |
@@ -43,7 +43,7 @@ jobs:
           name: Install OCaml test dependencies
           command: opam install --deps-only -t -y mssql
       - save_cache:
-          key: opam-v1-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
+          key: opam-v2-{{ arch }}-{{ checksum "mssql.opam" }}-{{ checksum "Makefile" }}
           paths:
             - ~/.opam
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
           name: Build
           command: opam config exec -- make
       - run:
+          name: Setup /etc configs
+          command: sudo cp config/* /etc/freetds/
+      - run:
           name: Test
           command: opam config exec -- make coverage
       - run:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ coverage: clean
 	  `find . -name 'bisect*.out'`
 
 pin:
-	# FreeTDS upstream holds the global OCaml lock; this branch fixes that
-	# Remove when this pull request is merged: https://github.com/kennknowles/ocaml-freetds/pull/29
+	# Various fixes to the ctlib bindings, and also release the runtime lock
+	# See https://github.com/kennknowles/ocaml-freetds/pull/30
 	opam pin add -yn freetds -k git \
-		https://github.com/arenadotio/ocaml-freetds\#release-lock-during-io
+		https://github.com/arenadotio/ocaml-freetds\#ctlib-release-runtime-lock
 	opam pin add -yn mssql .
 
 test:

--- a/config/freetds.conf
+++ b/config/freetds.conf
@@ -1,0 +1,4 @@
+[global]
+	tds version = 7.0
+	text size = 64512
+  client charset = CP1252

--- a/config/locales.conf
+++ b/config/locales.conf
@@ -1,0 +1,2 @@
+[default]
+	date format = %Y-%m-%d %H:%M:%S.%z

--- a/src/client.ml
+++ b/src/client.ml
@@ -41,7 +41,6 @@ let sequencer_enqueue t f =
       Throttle.enqueue conn f
 
 let run_query ~month_offset t query =
-  Logger.debug !"Executing query: %s" query;
   Or_error.try_with (fun () ->
     let cols cmd =
       Ct.res_info cmd `Numdata
@@ -120,6 +119,7 @@ let format_query query params =
 
 let execute' ({ month_offset } as t) query =
   sequencer_enqueue t @@ fun conn ->
+  Logger.debug !"Executing query: %s" query;
   In_thread.run (fun () ->
     run_query ~month_offset conn query)
 

--- a/src/client.mli
+++ b/src/client.mli
@@ -1,4 +1,3 @@
-open Core
 open Async
 
 type t

--- a/src/db_field.ml
+++ b/src/db_field.ml
@@ -12,7 +12,7 @@ type t =
   | Date of Time.t
 [@@deriving sexp]
 
-let recode str =
+let recode ~src ~dst str =
   (* Need to convert from CP1252 since SQL Server can't handle UTF-8 in any
      reasonable way.
      Note that //TRANSLIT means we will try to convert between similar
@@ -23,7 +23,8 @@ let recode str =
      doesn't fix either, so in that case we'll log the offending string and do a
      simple ascii filter. *)
   try
-    Encoding.recode_string ~src:"CP1252" ~dst:"UTF-8//TRANSLIT" str
+    let dst = sprintf "%s//TRANSLIT" dst in
+    Encoding.recode_string ~src ~dst str
   with exn ->
     Logger.info !"Recoding error, falling back to ascii filter %{sexp: exn} %s"
       exn str;
@@ -66,7 +67,7 @@ let of_data ~(month_offset:int) (data:Ct.sql_t) =
   | `Binary s -> Some (String s)
   | `Text s
   | `String s ->
-    Some (String (recode s))
+    Some (String (recode ~src:"CP1252" ~dst:"UTF-8" s))
   | `Datetime s ->
     let d = datetime_of_string s in
     Some (Date d)
@@ -96,11 +97,8 @@ let to_string_escaped =
      'a'+'s'+'d'+'f'). *)
   let quote_string s =
     (* Need to convert to CP1252 since SQL Server can't handle UTF-8 in any
-       reasonable way.
-       Note that //TRANSLIT means we will try to convert between similar
-       characters in the two encodings and use ? if necessary instead of
-       erroring out. *)
-    let s = Text.encode ~encoding:"CP1252//TRANSLIT" s in
+       reasonable way. *)
+    let s = recode ~src:"UTF-8" ~dst:"CP1252" s in
     (* len * 2 will always hold the resulting string unless it has null
        chars, so this should make the standard case fast without wasting much
        memory. *)

--- a/src/db_field.mli
+++ b/src/db_field.mli
@@ -14,7 +14,7 @@ type t =
   | Date of Time.t
 [@@deriving sexp]
 
-val of_data : month_offset:int -> Dblib.data -> t option
+val of_data : month_offset:int -> Ct.sql_t -> t option
 
 val to_string : t option -> string
 val to_string_escaped : t option -> string

--- a/src/logger.ml
+++ b/src/logger.ml
@@ -1,9 +1,21 @@
+open Core
 open Async
 
 let tags = [ "lib", "mssql" ]
 
+let log_in_thread level fmt =
+  ksprintf (fun str ->
+    Thread_safe.run_in_async_exn (fun () ->
+      Log.Global.printf ~level ~tags "%s" str)) fmt
+
 let debug fmt = Log.Global.debug ~tags fmt
+
+let debug_in_thread fmt= log_in_thread `Debug fmt
 
 let info fmt = Log.Global.info ~tags fmt
 
+let info_in_thread fmt = log_in_thread `Info fmt
+
 let error fmt = Log.Global.error ~tags fmt
+
+let error_in_thread fmt = log_in_thread `Error fmt

--- a/src/row.mli
+++ b/src/row.mli
@@ -5,7 +5,7 @@ open Freetds
 
 type t [@@deriving sexp_of]
 
-val create_exn : month_offset:int -> Dblib.data list -> string list -> t
+val create_exn : month_offset:int -> Ct.sql_t list -> string list -> t
 
 (** [to_alist t] converts t to a list of (colname, value) pairs *)
 val to_alist : t -> (string * string) list

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -517,6 +517,26 @@ let test_prevent_transaction_deadlock () =
                         expect (Error.to_string_mach err))
     | _ -> assert false)
 
+let test_concurrent_queries_actually_concurrent () =
+  let n = 5
+  and start = Time.now () in
+  Mssql.Test.with_pool ~max_connections:n (fun pool ->
+    List.init n ~f:(Fn.const ())
+    |> Deferred.List.iter ~how:`Parallel ~f:(fun () ->
+      Mssql.Pool.with_conn pool (fun db ->
+        (* wait for one second *)
+        Mssql.execute_unit db "WAITFOR DELAY '00:00:01'")))
+  >>| fun () ->
+  let end_ = Time.now () in
+  let diff =
+    Time.diff end_ start
+    |> Time.Span.to_sec
+  in
+  (* since we ran the queries in parallel, we should take less than 10 seconds
+     to finish *)
+  Float.(diff < of_int n)
+  |> assert_bool (sprintf "Expected concurrent queries to take less than %d seconds but took %f seconds" n diff)
+
 let () =
   [ "select and convert", test_select_and_convert
   ; "multiple queries in execute", test_multiple_queries_in_execute
@@ -539,7 +559,9 @@ let () =
   ; "test auto commit", test_auto_commit
   ; "test pool auto rollback", test_pool_auto_rollback
   ; "test other execute during transaction", test_other_execute_during_transaction
-  ; "test prevent transaction deadlock", test_prevent_transaction_deadlock ]
+  ; "test prevent transaction deadlock", test_prevent_transaction_deadlock
+  ; "concurrent queries actually concurrent",
+    test_concurrent_queries_actually_concurrent ]
   @ round_trip_tests
   |> List.map ~f:(fun (name, f) ->
     name >:: (fun _ ->

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -122,7 +122,7 @@ let test_select_and_convert () =
     assert_raises "date as bool" (fun () -> Row.bool row col);
 
     let col = "datetimecol" in
-    ae_sexp [%sexp_of: string option] (Some "1998-09-12 12:34:56.000000Z")
+    ae_sexp [%sexp_of: string option] (Some "Sep 12 1998 12:34:56:000PM")
       (Row.str row col);
     ae_sexp [%sexp_of: Date.t option] (Some (Date.of_string "1998-09-12"))
       (Row.date row col);
@@ -330,9 +330,9 @@ let round_trip_tests =
    ; "\x00a'"
    ; "\x00'asd"
    ; "'\x00asd"
+   ; "asd'\x00'"
    ; "'asd\x00"
-   ; "asd\x00"
-   ; "asd'\x00'" ]
+   ; "asd\x00" ]
    |> List.map ~f:(fun str ->
      (String str, "VARCHAR(256)", (fun row ->
         Row.str row ""

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -9,8 +9,18 @@ let ae_sexp ?cmp ?pp_diff ?msg sexp a a' =
   assert_equal ~cmp ?pp_diff ?msg
     ~printer:(fun x -> x |> sexp |> Sexp.to_string_hum) a a'
 
-let async_test' timeout f =
+let async_test' ctx timeout f =
   Thread_safe.block_on_async_exn @@ fun () ->
+  [ Log.Output.create ~flush:(Fn.const Deferred.unit) (fun msgs ->
+      Queue.iter msgs ~f:(fun msg ->
+        let level : OUnit2.log_severity =
+          match Log.Message.level msg with
+          | None | Some `Debug | Some `Info -> `Info
+          | Some `Error -> `Error
+        in
+        OUnit2.logf ctx level "%s" (Log.Message.message msg));
+      Deferred.unit) ]
+  |> Log.Global.set_output;
   Clock.with_timeout timeout (f ())
   >>| function
   | `Result x -> x
@@ -18,8 +28,8 @@ let async_test' timeout f =
     failwithf "Test exceeded timeout of %f seconds"
       (Time.Span.to_sec timeout) ()
 
-let async_test f =
-  async_test' (Time.Span.of_sec 10.) f
+let async_test ctx f =
+  async_test' ctx (Time.Span.of_sec 10.) f
 
 let test_select_and_convert () =
   Mssql.Test.with_conn (fun db ->
@@ -588,9 +598,9 @@ let () =
   @ round_trip_tests
   @ recoding_tests
   |> List.map ~f:(fun (name, f) ->
-    name >:: (fun _ ->
+    name >:: (fun ctx ->
       try
-        async_test @@ fun () ->
+        async_test ctx @@ fun () ->
         f ()
       with exn ->
         Monitor.extract_exn exn

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -543,7 +543,11 @@ let () =
   @ round_trip_tests
   |> List.map ~f:(fun (name, f) ->
     name >:: (fun _ ->
-      async_test @@ fun () ->
-      f ()))
+      try
+        async_test @@ fun () ->
+        f ()
+      with exn ->
+        Monitor.extract_exn exn
+        |> raise))
   |> test_list
   |> run_test_tt_main

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -122,7 +122,7 @@ let test_select_and_convert () =
     assert_raises "date as bool" (fun () -> Row.bool row col);
 
     let col = "datetimecol" in
-    ae_sexp [%sexp_of: string option] (Some "Sep 12 1998 12:34:56:000PM")
+    ae_sexp [%sexp_of: string option] (Some "1998-09-12 12:34:56.000")
       (Row.str row col);
     ae_sexp [%sexp_of: Date.t option] (Some (Date.of_string "1998-09-12"))
       (Row.date row col);


### PR DESCRIPTION
Doing this because the Ctlib bindings don't use callbacks so we think it will be easier to release the runtime lock safely.