### PR TITLE
Concurrency again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,13 @@ coverage: clean
 	  `find . -name 'bisect*.out'`
 
 pin:
-	# General improvements to ocaml-freetds's dblib bindings
-	# Remove when this pull request is merged: https://github.com/kennknowles/ocaml-freetds/pull/31
+	# Improvements to ocaml-freetds's bindings, and code to release the runtime
+	# lock
+	# Remove when these pull requests are merged:
+	# https://github.com/kennknowles/ocaml-freetds/pull/31
+	# https://github.com/kennknowles/ocaml-freetds/pull/32
 	opam pin add -yn freetds -k git \
-		https://github.com/arenadotio/ocaml-freetds\#dblib-improvements
+		https://github.com/arenadotio/ocaml-freetds\#release-lock-during-io
 	opam pin add -yn mssql .
 
 test:

--- a/src/client.ml
+++ b/src/client.ml
@@ -14,12 +14,6 @@ type t =
      http://www.pymssql.org/en/stable/freetds_and_dates.html *)
   ; month_offset : int }
 
-let thread = lazy (In_thread.Helper_thread.create ~name:"mssql" ())
-
-let in_thread f =
-  let%bind thread = Lazy.force thread in
-  In_thread.run ~thread f
-
 let next_transaction_id =
   let next = ref Bigint.zero in
   fun () ->
@@ -102,7 +96,7 @@ let format_query query params =
 
 let execute' ({ month_offset } as t) query =
   sequencer_enqueue t @@ fun conn ->
-  in_thread (fun () ->
+  In_thread.run (fun () ->
     run_query ~month_offset conn query)
 
 let with_query_in_exn query formatted_query f =
@@ -253,12 +247,12 @@ let close ({ conn } as t) =
   | Some conn ->
     t.conn <- None;
     Throttle.enqueue conn @@ fun conn ->
-    in_thread (fun () -> Dblib.close conn)
+    In_thread.run (fun () -> Dblib.close conn)
 
 let create ~host ~db ~user ~password () =
   let%bind conn =
     let%map conn =
-      in_thread (connect ~host ~db ~user ~password)
+      In_thread.run (connect ~host ~db ~user ~password)
       >>| Sequencer.create ~continue_on_error:true
     in
     { conn = Some conn


### PR DESCRIPTION
Try once again to become concurrent.

This has more tests, and passes our internal test suite.

The main change here is that upstream we properly handle strings when
releasing the OCaml runtime lock (we need to copy any OCaml string we
want to access, since the GC is allowed to move any other strings when
the lock is released).