### PR TITLE
Replace Failure with Mssql_error

### DIFF
--- a/src/mssql.ml
+++ b/src/mssql.ml
@@ -1,4 +1,7 @@
+module Error = Mssql_error
 module Param = Db_field
 module Row = Row
 module Test = Test
 include Client
+
+exception Error = Error.Mssql_error

--- a/src/mssql_error.ml
+++ b/src/mssql_error.ml
@@ -1,0 +1,64 @@
+open Core_kernel
+
+type t =
+  { msg : string
+  ; reraised_exn : Exn.t sexp_option
+  ; here : Source_code_position.t
+  ; query : string sexp_option
+  ; params : Db_field.t option sexp_list
+  ; formatted_query : string sexp_option
+  ; results : Row.t list sexp_list }
+[@@deriving sexp_of]
+
+exception Mssql_error of t
+[@@deriving sexp_of]
+
+let make ~msg ?exn ~here ?query ?(params=[]) ?formatted_query ?(results=[]) () =
+  Mssql_error
+    { msg
+    ; reraised_exn = exn
+    ; here
+    ; query
+    ; params
+    ; formatted_query
+    ; results }
+
+let failwith ?query ?params ?formatted_query ?results ?exn ?backtrace
+      here msg =
+  let exn = make ~here ~msg ?query ?params ?formatted_query ?results ?exn () in
+  match backtrace with
+  | None ->
+    raise exn
+  | Some backtrace ->
+    Caml.Printexc.raise_with_backtrace exn backtrace
+
+let failwithf ?query ?params ?formatted_query ?results ?exn ?backtrace
+      here fmt =
+  ksprintf (fun msg ->
+    failwith ?query ?params ?formatted_query ?results ?exn ?backtrace here msg)
+    fmt
+
+let with_wrap ?query ?(params=[]) ?formatted_query ?(results=[]) here f =
+  try
+    f ()
+  with
+  | (Mssql_error t) ->
+    let backtrace = Caml.Printexc.get_raw_backtrace () in
+    let exn =
+      (* Preserve original info if set, but override if not set *)
+      (* Note that we never mess with the original [%here] *)
+      Mssql_error
+        { t with
+          query = Option.first_some t.query query
+        ; params = (match t.params with [] -> params | _ -> t.params)
+        ; formatted_query = Option.first_some t.formatted_query formatted_query
+        ; results = (match t.results with [] -> results | _ -> t.results) }
+    in
+    Caml.Printexc.raise_with_backtrace exn backtrace
+  | (Freetds.Dblib.Error (_, msg)) as exn ->
+    let backtrace = Caml.Printexc.get_raw_backtrace () in
+    failwith here ?query ~params ?formatted_query ~backtrace ~exn msg
+  | exn ->
+    let backtrace = Caml.Printexc.get_raw_backtrace () in
+    failwith here ?query ~params ?formatted_query ~backtrace ~exn
+      "Unexpected error in Dblib"

--- a/src/mssql_error.mli
+++ b/src/mssql_error.mli
@@ -1,0 +1,59 @@
+(** Module for the general Mssql exception type [Mssql_error]. This lets us
+    raise nice exception that always have their source code position, and
+    optionally contain a query string, parameters, formatted query string, and
+    result rows *)
+open Core_kernel
+
+type t =
+  { msg : string
+  ; reraised_exn : Exn.t option
+  ; here : Source_code_position.t
+  ; query : string option
+  ; params : Db_field.t option list
+  ; formatted_query : string option
+  ; results : Row.t list list }
+[@@deriving sexp_of]
+
+exception Mssql_error of t
+[@@deriving sexp_of]
+
+(** [failwith [%here] msg] raises a [Mssql_error] with the given options and
+    message *)
+val failwith
+  : ?query:string
+  -> ?params:Db_field.t option list
+  -> ?formatted_query:string
+  -> ?results:Row.t list list
+  -> ?exn:Exn.t
+  -> ?backtrace:Caml.Printexc.raw_backtrace
+  -> Source_code_position.t
+  -> string
+  -> _
+
+(** [failwithf [%here] "%..." msg] raises a [Mssql_error] with the given
+    options and a sprintf formatted message *)
+val failwithf
+  : ?query:string
+  -> ?params:Db_field.t option list
+  -> ?formatted_query:string
+  -> ?results:Row.t list list
+  -> ?exn:Exn.t
+  -> ?backtrace:Caml.Printexc.raw_backtrace
+  -> Source_code_position.t
+  -> ('a, unit, string, _) format4
+  -> 'a
+
+(** [with_wrap_dblib_error [%here] f] calls [f] and if it throws an exception,
+    wraps the error in [Mssql_error]. There are special cases for if the exn
+    thrown is already [Mssql_error] (we always preserve the [%here] and preserve
+    the other info if not set), and for [Dblib.Error] (using the message
+    directly, to make exceptions more readable -- although we also set
+    [reraised_exn] so the original info is all there) *)
+val with_wrap
+  : ?query:string
+  -> ?params:Db_field.t option list
+  -> ?formatted_query:string
+  -> ?results:Row.t list list
+  -> Source_code_position.t
+  -> (unit -> 'a)
+  -> 'a


### PR DESCRIPTION
This is a structure error for any Mssql error, which lets us attach
the source code position, query, params, formatted query, reraised
exn, etc.

The main benefit of this is that the error message will be at the
top, so it should be easier to see at-a-glance what happened with
a Sentry error.