### PR TITLE
Fix opam file errors

### DIFF
--- a/mssql.opam
+++ b/mssql.opam
@@ -1,8 +1,8 @@
-opam-version: "1.2"
+opam-version: "2.0"
 authors: ["Arena Developers <silver-snakes@arena.io>"]
 maintainer: "silver-snakes@arena.io"
 homepage: "https://github.com/arenadotio/ocaml-mssql"
-dev-repo: "https://github.com/arenadotio/ocaml-mssql.git"
+dev-repo: "git+https://github.com/arenadotio/ocaml-mssql.git"
 bug-reports: "https://github.com/arenadotio/ocaml-mssql/issues"
 doc: "https://arenadotio.github.io/ocaml-mssql/doc"
 
@@ -14,6 +14,7 @@ depends: [
   "bignum"
   "ppx_jane"
   "freetds"
+  "ocaml" {>= "4.06.1"}
   "ounit"
   "logs"
   "text" {>= "0.8.0"}
@@ -21,5 +22,3 @@ depends: [
   "bisect_ppx" {build & >= "1.3.1"}
   "dune" {build & >= "1.4"}
 ]
-
-available: [ocaml-version >= "4.06.1"]


### PR DESCRIPTION
opam is extremely picky and apparently it's an error to do things
like rely on deprecated fields or have your source code not be
a git link.