### PR TITLE
Switch from Dblib.canquery to Dblib.cancel

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -48,7 +48,7 @@ let run_query ~month_offset t query =
     |> List.range 0
     |> List.map ~f:(fun i -> Dblib.colname t (i + 1))
   in
-  Dblib.canquery t;
+  Dblib.cancel t;
   Dblib.sqlexec t query;
   let rec result_set_loop result_sets =
     match Dblib.results t with


### PR DESCRIPTION
See docs:

http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.ocs_12.5.1.dblib/html/dblib/X15355.htm
http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.ocs_12.5.1.dblib/html/dblib/X57019.htm

dbcanquery cancels the current query and discards results.

dbcancel cancels all current commands discards results.

We're calling this to ensure the connection is in a good state, so
dbcancel is what we want.

This should fix occasional errors where we get an exception
because a command in still in progress (presumably an incomplete
command from an exception).