### PR TITLE
Revert "Pin ocaml-freetds commit to release runtime lock"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,10 @@ coverage: clean
 	  `find . -name 'bisect*.out'`
 
 pin:
-	# Improvements to ocaml-freetds's bindings, and code to release the runtime
-	# lock
-	# Remove when these pull requests are merged:
-	# https://github.com/kennknowles/ocaml-freetds/pull/31
-	# https://github.com/kennknowles/ocaml-freetds/pull/32
+	# General improvements to ocaml-freetds's dblib bindings
+	# Remove when this pull request is merged: https://github.com/kennknowles/ocaml-freetds/pull/31
 	opam pin add -yn freetds -k git \
-		https://github.com/arenadotio/ocaml-freetds\#release-lock-during-io
+		https://github.com/arenadotio/ocaml-freetds\#dblib-improvements
 	opam pin add -yn mssql .
 
 test:

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -529,26 +529,6 @@ let test_prevent_transaction_deadlock () =
                         expect (Error.to_string_mach err))
     | _ -> assert false)
 
-let test_concurrent_queries_actually_concurrent () =
-  let n = 5
-  and start = Time.now () in
-  Mssql.Test.with_pool ~max_connections:n (fun pool ->
-    List.init n ~f:(Fn.const ())
-    |> Deferred.List.iter ~how:`Parallel ~f:(fun () ->
-      Mssql.Pool.with_conn pool (fun db ->
-        (* wait for one second *)
-        Mssql.execute_unit db "WAITFOR DELAY '00:00:01'")))
-  >>| fun () ->
-  let end_ = Time.now () in
-  let diff =
-    Time.diff end_ start
-    |> Time.Span.to_sec
-  in
-  (* since we ran the queries in parallel, we should take less than 10 seconds
-     to finish *)
-  Float.(diff < of_int n)
-  |> assert_bool (sprintf "Expected concurrent queries to take less than %d seconds but took %f seconds" n diff)
-
 let () =
   [ "select and convert", test_select_and_convert
   ; "multiple queries in execute", test_multiple_queries_in_execute
@@ -569,9 +549,7 @@ let () =
   ; "test commit", test_commit
   ; "test auto commit", test_auto_commit
   ; "test other execute during transaction", test_other_execute_during_transaction
-  ; "test prevent transaction deadlock", test_prevent_transaction_deadlock
-  ; "concurrent queries actually concurrent",
-    test_concurrent_queries_actually_concurrent ]
+  ; "test prevent transaction deadlock", test_prevent_transaction_deadlock ]
   @ round_trip_tests
   @ recoding_tests
   |> List.map ~f:(fun (name, f) ->


### PR DESCRIPTION
This reverts commit 81188f4b946db1b8e2848334dd92adfe4846b39f.

We started seeing inexplicable syntax errors in our systems again :'(