### PR TITLE
Don't throw exceptions in Dblib C callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,12 @@ coverage: clean
 
 pin:
 	# General improvements to ocaml-freetds's dblib bindings
-	# Remove when this pull request is merged: https://github.com/kennknowles/ocaml-freetds/pull/31
+	# See https://github.com/arenadotio/ocaml-freetds/tree/dblib-dont-throw-exceptions-in-callbacks
+	# Remove when these pull requests are merged:
+	# https://github.com/kennknowles/ocaml-freetds/pull/31
+	# https://github.com/kennknowles/ocaml-freetds/pull/33
 	opam pin add -yn freetds -k git \
-		https://github.com/arenadotio/ocaml-freetds\#dblib-improvements
+		https://github.com/arenadotio/ocaml-freetds\#1ad2ce3111a5f0413fbc4f8f6fc223e18032ce01
 	opam pin add -yn mssql .
 
 test:

--- a/src/client.ml
+++ b/src/client.ml
@@ -198,12 +198,6 @@ let with_transaction_or_error t f =
     Monitor.try_with_join_or_error (fun () ->
       f t))
 
-let ignore_conversion_err_handler severity _err msg =
-  match severity with
-  | Dblib.CONVERSION ->
-    Logger.info "Ignoring conversion error: %s" msg;
-  | _ -> raise (Dblib.Error(severity, msg))
-
 let rec connect ?(tries=5) ~host ~db ~user ~password () =
   try
     let conn =
@@ -220,7 +214,6 @@ let rec connect ?(tries=5) ~host ~db ~user ~password () =
         host
     in
     Dblib.use conn db;
-    Dblib.err_handler ignore_conversion_err_handler;
     conn
   with exn ->
     if tries = 0 then


### PR DESCRIPTION
Throwing exceptions does terrible things to the C stack, which FreeTDS can't handle.

This uses changes in the FreeTDS OCaml bindings to hold onto C exceptions and rethrow
them after FreeTDS finishes.

See https://github.com/kennknowles/ocaml-freetds/pull/33