### PR TITLE
Handle port correctly and make argument optional

### DIFF
--- a/src/client.mli
+++ b/src/client.mli
@@ -10,7 +10,7 @@ val with_conn
   -> db:string
   -> user:string
   -> password:string
-  -> port:string
+  -> ?port:int
   -> (t -> 'a Deferred.t)
   -> 'a Deferred.t
 
@@ -84,7 +84,7 @@ module Pool : sig
     -> db:string
     -> user:string
     -> password:string
-    -> port:string
+    -> ?port:int
     -> ?max_connections:int
     -> (p -> 'a Deferred.t)
     -> 'a Deferred.t

--- a/src/test.ml
+++ b/src/test.ml
@@ -9,15 +9,15 @@ let params =
     ; "MSSQL_TEST_PORT" ]
     |> List.map ~f:Sys.getenv
     |> function
-    | [ Some host ; Some db ; Some user ; Some password ; Some port ] ->
-      host, db, user, password, port
+    | [ Some host ; Some db ; Some user ; Some password ; port ] ->
+      host, db, user, password, Option.map ~f:Int.of_string port
     | _ -> raise (OUnitTest.Skip "MSSQL_TEST_* environment not set"))
 
 let with_conn f =
   let host, db, user, password, port = Lazy.force params in
-  Client.with_conn ~host ~db ~user ~password ~port f
+  Client.with_conn ~host ~db ~user ~password ?port f
 
 let with_pool ?max_connections f =
   let host, db, user, password, port = Lazy.force params in
-  Client.Pool.with_pool ~host ~db ~user ~password ~port ?max_connections f
+  Client.Pool.with_pool ~host ~db ~user ~password ?port ?max_connections f
 


### PR DESCRIPTION
 - Make port an int
 - Make it optional
 - Actually use the port when connecting

Note: The change from string to int in the argument type isn't
backwards compatible so this is a breaking change.