### PR TITLE
Make logging pass the original Async context around

### DIFF
--- a/src/db_field.mli
+++ b/src/db_field.mli
@@ -16,7 +16,12 @@ type t =
   | Array of t list
 [@@deriving sexp]
 
-val of_data : month_offset:int -> Dblib.data -> t option
+val of_data
+  :  context:Async_kernel.Execution_context.t
+  -> month_offset:int
+  -> Dblib.data
+  -> t option
+
 val to_string : t option -> string
 val to_string_escaped : t option -> string
 val bignum : ?column:string -> t -> Bignum.t

--- a/src/row.ml
+++ b/src/row.ml
@@ -2,8 +2,8 @@ open Core
 
 type t = Db_field.t option String.Map.t [@@deriving sexp_of]
 
-let create_exn ~month_offset ~colnames row =
-  List.map row ~f:(Db_field.of_data ~month_offset)
+let create_exn ~context ~month_offset ~colnames row =
+  List.map row ~f:(Db_field.of_data ~context ~month_offset)
   |> List.zip_exn colnames
   |> String.Map.of_alist_exn
 ;;

--- a/src/row.mli
+++ b/src/row.mli
@@ -6,7 +6,12 @@ open Freetds
 
 type t [@@deriving sexp_of]
 
-val create_exn : month_offset:int -> colnames:string list -> Dblib.data list -> t
+val create_exn
+  :  context:Async_kernel.Execution_context.t
+  -> month_offset:int
+  -> colnames:string list
+  -> Dblib.data list
+  -> t
 
 (** [to_alist t] converts t to a list of (colname, value) pairs *)
 val to_alist : t -> (string * string) list


### PR DESCRIPTION
This should make tagging systems which use the Async context
work correctly.