### PR TITLE
Various fixes

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -125,7 +125,6 @@ let execute_multi_result ?params conn query =
 (* Execute [f iter] for the first result set iterator and throw an exception if there is more than
    one result set *)
 let execute_f' ?params ~f conn query =
-  let f = Scheduler.preserve_execution_context' f |> Staged.unstage in
   execute_multi_result' ?params conn query ~f:(fun result_sets ->
       let result =
         let input =

--- a/src/query_lexer.mll
+++ b/src/query_lexer.mll
@@ -7,8 +7,9 @@
 (* The lexer parsers queries into quoted strings, parameters, and everything
    else. This lets us avoid replacing parameters in literal strings. *)
 rule token = parse
-  | '"' ([^'"']* as s) '"' { DOUBLE_QUOTE_STRING s }
-  | '\'' ([^ '\'']* as s) '\'' { SINGLE_QUOTE_STRING s }
-  | "$" (['0'-'9']+ as s) { PARAM (int_of_string s) }
+  | ("--" [^'\n']* '\n') as s { COMMENT s }
+  | ('\'' [^ '\'']* '\'') as s { SINGLE_QUOTE_STRING s }
+  | ('"' [^'"']* '"') as s { DOUBLE_QUOTE_STRING s }
+  | '$' (['0'-'9']+ as s) { PARAM (int_of_string s) }
   | _ as c { OTHER (Char.to_string c) }
   | eof { EOF }

--- a/src/query_parser.mly
+++ b/src/query_parser.mly
@@ -3,6 +3,7 @@
   open Query_parser_types
 %}
 
+%token <string> COMMENT
 %token <int> PARAM
 %token <string> DOUBLE_QUOTE_STRING
 %token <string> SINGLE_QUOTE_STRING
@@ -15,9 +16,10 @@
 %%
 
 expression:
+| COMMENT { Other $1 }
 | PARAM { Param $1 }
-| DOUBLE_QUOTE_STRING { Other (sprintf "\"%s\"" $1) }
-| SINGLE_QUOTE_STRING { Other (sprintf "'%s'" $1) }
+| DOUBLE_QUOTE_STRING { Other $1 }
+| SINGLE_QUOTE_STRING { Other $1 }
 | OTHER { Other $1 }
 
 main:

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -610,8 +610,8 @@ let test_execute_pipe () =
 let test_execute_pipe_error () =
   with_test_conn (fun db ->
       Monitor.try_with_or_error ~here:[%here]
-      @@ fun () -> Mssql.execute_unit db "lkmsdflkmdsf")
-  >>| [%test_pred: unit Or_error.t]
+      @@ fun () -> Mssql.execute_pipe db "lkmsdflkmdsf" |> Pipe.to_list)
+  >>| [%test_pred: Mssql.Row.t list Or_error.t]
         Result.is_error
         ~message:"Invalid query should return an error"
 ;;

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -616,6 +616,20 @@ let test_execute_pipe_error () =
         ~message:"Invalid query should return an error"
 ;;
 
+let test_query_with_quote_comment () =
+  with_test_conn (fun db ->
+      Mssql.execute_single
+        db
+        ~params:Mssql.Param.[ Some (String "test") ]
+        {|
+          -- comment with quote'
+          SELECT $1 AS x
+          -- another comment with quote'
+        |})
+  >>| Option.map ~f:(fun row -> Mssql.Row.str_exn row "x")
+  >>| [%test_result: string option] ~expect:(Some "test")
+;;
+
 let () =
   try
     (Lazy.force params : string * string * string * string * int option) |> ignore;
@@ -647,6 +661,7 @@ let () =
         ; "test exception with multiple results", test_exception_with_multiple_results
         ; "test execute_pipe", test_execute_pipe
         ; "test execute_pipe_error", test_execute_pipe_error
+        ; "query with quote in comment", test_query_with_quote_comment
         ]
         @ round_trip_tests
         @ recoding_tests


### PR DESCRIPTION
- Fix execute_pipe error handling
- Fix handling of quotes in comments in our parameter parser
- Fix hang in execute_map in some cases
- Make it harder to leave our result set iterator in a bad state
- Cancel queries immediately on failure instead of waiting for the next query