### PR TITLE
Defensively cancel any in-progress queries

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -84,6 +84,7 @@ let execute' ?params ~query ~formatted_query ({ month_offset; _ } as t) ~f =
   In_thread.run
   @@ fun () ->
   Mssql_error.with_wrap ~query ?params ~formatted_query [%here] (fun () ->
+      Dblib.cancel conn;
       Dblib.sqlexec conn formatted_query;
       let iter =
         let previous_result_set = ref Iter.empty in


### PR DESCRIPTION
We try to cancel queries immediately on error, but we're finding
cases where we still get the "Attempt to initiate a new Adaptive
Server operation with results pending" error.

This defensively cancels at the start of a query too, which should
help prevent that.