### PR TITLE
Add support for DATETIME2

### DIFF
--- a/src/db_field.ml
+++ b/src/db_field.ml
@@ -255,6 +255,6 @@ let date ?column =
 let datetime ?column =
   with_error_msg ?column "datetime" ~f:(function
       | Date d -> d
-      | String s -> Time.of_string_abs s
+      | String s -> Time.of_string_gen ~if_no_timezone:(`Use_this_one Time.Zone.utc) s
       | _ -> assert false)
 ;;

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -356,7 +356,18 @@ let round_trip_tests =
         |> [%test_result: int64 option] ~expect:(Some Int64.(max_value / of_int 1000000))
     )
   ; ( Date (Time.of_string "2017-01-05 11:53:02Z")
+    , "DATE"
+    , fun row ->
+        Row.date row ""
+        |> [%test_result: Date.t option] ~expect:(Some (Date.of_string "2017-01-05")) )
+  ; ( Date (Time.of_string "2017-01-05 11:53:02Z")
     , "DATETIME"
+    , fun row ->
+        Row.datetime row ""
+        |> [%test_result: Time.t option]
+             ~expect:(Some (Time.of_string "2017-01-05 11:53:02Z")) )
+  ; ( Date (Time.of_string "2017-01-05 11:53:02Z")
+    , "DATETIME2"
     , fun row ->
         Row.datetime row ""
         |> [%test_result: Time.t option]


### PR DESCRIPTION
It seems that the freetds layer returns this as a string that Time.of_string_abs
doesn't like (it's missing the Z at the end and doesn't have a T between the date
and time part). Using Time.of_string_gen works.