### PR TITLE
Upgrade to TDS 7.2 by default

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -369,7 +369,7 @@ let create ?tds_version ~host ~db ~user ~password ?port () =
     raise exn
 ;;
 
-let with_conn ~host ~db ~user ~password ?port f =
-  let%bind conn = create ~host ~db ~user ~password ?port () in
+let with_conn ?tds_version ~host ~db ~user ~password ?port f =
+  let%bind conn = create ?tds_version ~host ~db ~user ~password ?port () in
   Monitor.protect (fun () -> f conn) ~finally:(fun () -> close conn)
 ;;

--- a/src/client.mli
+++ b/src/client.mli
@@ -10,7 +10,7 @@ type t
     unhandled by ocaml-freetds
     *)
 val with_conn
-  :  tds_version:Freetds.Dblib.version
+  :  ?tds_version:Freetds.Dblib.version
   -> host:string
   -> db:string
   -> user:string

--- a/src/client.mli
+++ b/src/client.mli
@@ -4,9 +4,14 @@ type t
 
 (** Opens a connection, runs the callback, then closes the connection. Don't
     try to use the DB handle outside of the callback, since it will have been
-    closed automatically. *)
+    closed automatically.
+
+    Note: FreeTDS version 7.0 doesn't support encryption, and versions above 7.2 use date types that are
+    unhandled by ocaml-freetds
+    *)
 val with_conn
-  :  host:string
+  :  tds_version:Freetds.Dblib.version
+  -> host:string
   -> db:string
   -> user:string
   -> password:string

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -738,7 +738,9 @@ let () =
         ]
         @ round_trip_tests
         @ recoding_tests
-        |> List.map ~f:(fun (name, f) -> Alcotest_async.test_case name `Quick f) )
+        |> List.map ~f:(fun (name, f) ->
+               Alcotest_async.test_case name ~timeout:(Time.Span.of_int_sec 10) `Quick f)
+      )
     ]
     |> Alcotest_async.run "mssql"
   with

--- a/test/test_mssql.ml
+++ b/test/test_mssql.ml
@@ -739,6 +739,8 @@ let () =
         @ round_trip_tests
         @ recoding_tests
         |> List.map ~f:(fun (name, f) ->
+               (* Note: If you run these tests against a local DB, they're much faster, but this longer timeout
+                  allows us to run them against remote RDS instances with TLS enabled *)
                Alcotest_async.test_case name ~timeout:(Time.Span.of_int_sec 10) `Quick f)
       )
     ]


### PR DESCRIPTION
- Add the ability to pick the TDS version
- Default to 7.2 (which supports encryption)

There was a comment about TDS > 7.0 not working, but it seems to be
working now. I assume this was a FreeTDS version issue, or maybe
something we fixed with more data type handling.