### PR TITLE
Gitignore _opam folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.install
 _build
+_opam
 
 .vimrc
 .nvimrc


### PR DESCRIPTION
This folder is used for local opam switches.